### PR TITLE
Revert "Update redhat/ubi9-minimal Docker tag to v9.8-1782191395"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN nginxPackages=" \
     && cp /root/rpmbuild/RPMS/$(arch)/* /nginx/
 
 
-FROM redhat/ubi9-minimal:9.8-1782191395 AS final
+FROM redhat/ubi9-minimal:9.8 AS final
 ARG NGINX
 ARG NJS
 ENV NGINX_VERSION=${NGINX}

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.25
-FROM redhat/ubi9-minimal:9.8-1782191395 AS final
+FROM redhat/ubi9-minimal:9.8 AS final
 ARG NGINX
 ARG NJS
 ENV NGINX_VERSION=${NGINX}


### PR DESCRIPTION
Reverts lucacome/nginx-ubi#494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base images to use simplified tag versions for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->